### PR TITLE
Set upper bound on Prism and RBS to avoid breaking changes

### DIFF
--- a/repl_type_completor.gemspec
+++ b/repl_type_completor.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "prism", ">= 0.18.0"
-  spec.add_dependency "rbs", ">= 2.7.0"
+  spec.add_dependency "prism", ">= 0.18.0", "< 0.19.0"
+  spec.add_dependency "rbs", ">= 2.7.0", "< 4.0.0"
 end


### PR DESCRIPTION
This will make sure a given version of this gem will pick up the compatible versions of dependencies.