### PR TITLE
Fix private method completion inside module

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -162,7 +162,7 @@ module ReplTypeCompletor
       end
       def transform() = yield(self)
       def methods() = @module_or_class.methods
-      def all_methods() = methods | Kernel.methods
+      def all_methods() = methods | @module_or_class.private_methods
       def constants() = @module_or_class.constants
       def types() = [self]
       def nillable?() = false

--- a/test/repl_type_completor/test_types.rb
+++ b/test/repl_type_completor/test_types.rb
@@ -66,14 +66,28 @@ module TestReplTypeCompletor
         private def foobaz; end
       end
       String.define_method(:foobarbaz) {}
-      targets = [:foobar, :foobaz, :foobarbaz]
+      targets = [:foobar, :foobaz, :foobarbaz, :rand]
       type = ReplTypeCompletor::Types.type_from_object s
       assert_equal [:foobar, :foobarbaz], targets & type.methods
-      assert_equal [:foobar, :foobaz, :foobarbaz], targets & type.all_methods
+      assert_equal [:foobar, :foobaz, :foobarbaz, :rand], targets & type.all_methods
       assert_equal [:foobarbaz], targets & ReplTypeCompletor::Types::STRING.methods
-      assert_equal [:foobarbaz], targets & ReplTypeCompletor::Types::STRING.all_methods
+      assert_equal [:foobarbaz, :rand], targets & ReplTypeCompletor::Types::STRING.all_methods
     ensure
       String.remove_method :foobarbaz
+    end
+
+    def test_singleton_type_methods
+      m = Module.new do
+        class << self
+          def foobar; end
+          private def foobaz; end
+        end
+      end
+      type = ReplTypeCompletor::Types::SingletonType.new(m)
+      assert_include type.methods, :foobar
+      assert_not_include type.methods, :foobaz
+      assert_include type.all_methods, :foobaz
+      assert_include type.all_methods, :rand
     end
 
     def test_basic_object_methods


### PR DESCRIPTION
```
irb(main):001* class A
irb(main):002*   class << self
irb(main):003*     def foo; end
irb(main):004*     private def bar; end
irb(main):005*   end
irb(main):006> end
=> :bar
irb(main):007* class A
irb(main):008*   self. # [:foo, :bar, :rand] should be in completion, but :bar was missing
```

`A.methods | A.private_methods` are callable here, but repl_type_completor was using `A.methods | Kernel.methods` instead.
(`Kernlel.methods` is included in `A.methods | A.private_methods`)