### PR TITLE
Require prism >= 0.19.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        prism: ['0.18.0']
+        prism: ['latest', '0.19.0']
     env:
       GEMFILE_PRISM_VERSION: ${{matrix.prism}}
     steps:

--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -91,8 +91,8 @@ module ReplTypeCompletor
         else
           [:symbol, name] unless name.empty?
         end
-      when Prism::CallNode
-        return if target_node.opening
+      when Prism::CallNode, Prism::CallTargetNode
+        return if target_node.is_a?(Prism::CallNode) && target_node.opening
 
         name = target_node.message.to_s
         return [:lvar_or_method, name, calculate_scope.call] if target_node.receiver.nil?

--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -75,11 +75,8 @@ module ReplTypeCompletor
         return unless call_node.is_a?(Prism::CallNode) && call_node.receiver.nil?
         return unless args_node.is_a?(Prism::ArgumentsNode) && args_node.arguments.size == 1
 
-        case call_node.name
-        when :require
-          [:require, target_node.content]
-        when :require_relative
-          [:require_relative, target_node.content]
+        if call_node.name == :require || call_node.name == :require_relative
+          [call_node.name, target_node.content]
         end
       when Prism::SymbolNode
         return unless !target_node.closing || target_node.empty?

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -923,8 +923,7 @@ module ReplTypeCompletor
       node.posts.zip posts do |n, v|
         assign_required_parameter n, v, scope
       end
-      if node.rest&.name
-        # node.rest is Prism::RestParameterNode
+      if node.rest.is_a?(Prism::RestParameterNode) && node.rest.name
         scope[node.rest.name.to_s] = Types.array_of(*rest)
       end
       node.keywords.each do |n|

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -902,7 +902,6 @@ module ReplTypeCompletor
       args = sized_splat(args.first, :to_ary, size) if size >= 2 && args.size == 1
       reqs = args.shift node.requireds.size
       if node.rest
-        # node.rest is Prism::RestParameterNode
         posts = []
         opts = args.shift node.optionals.size
         rest = args
@@ -923,6 +922,7 @@ module ReplTypeCompletor
       node.posts.zip posts do |n, v|
         assign_required_parameter n, v, scope
       end
+      # Prism::ImplicitRestNode (tap{|a,|}) does not have a name
       if node.rest.is_a?(Prism::RestParameterNode) && node.rest.name
         scope[node.rest.name.to_s] = Types.array_of(*rest)
       end

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -231,7 +231,6 @@ module ReplTypeCompletor
 
 
     def evaluate_call_node(node, scope)
-      is_field_assign = node.name.match?(/[^<>=!\]]=\z/) || (node.name == :[]= && !node.call_operator)
       receiver_type = node.receiver ? evaluate(node.receiver, scope) : scope.self_type
       evaluate_method = lambda do |scope|
         args_types, kwargs_types, block_sym_node, has_block = evaluate_call_node_arguments node, scope
@@ -280,7 +279,7 @@ module ReplTypeCompletor
           call_block_proc = ->(_block_args, _self_type) { Types::OBJECT }
         end
         result = method_call receiver_type, node.name, args_types, kwargs_types, call_block_proc, scope
-        if is_field_assign
+        if node.attribute_write?
           args_types.last || Types::NIL
         else
           result

--- a/repl_type_completor.gemspec
+++ b/repl_type_completor.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "prism", ">= 0.18.0", "< 0.19.0"
+  spec.add_dependency "prism", ">= 0.19.0", "< 0.20.0"
   spec.add_dependency "rbs", ">= 2.7.0", "< 4.0.0"
 end

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -29,6 +29,8 @@ module TestReplTypeCompletor
     def test_require
       assert_completion("require '", include: 'set')
       assert_completion("require 's", include: 'et')
+      assert_completion('require "', include: 'set')
+      assert_completion('require "s', include: 'et')
       assert_completion("require_relative 'test_", filename: __FILE__, include: 'repl_type_completor')
       assert_completion("require_relative '../repl_", filename: __FILE__, include: 'type_completor/test_repl_type_completor')
       Dir.chdir File.join(__dir__, '..') do
@@ -36,9 +38,9 @@ module TestReplTypeCompletor
         assert_completion("require_relative 'repl_", filename: '(irb)', include: 'type_completor/test_repl_type_completor')
       end
 
-      # Incomplete double quote string is InterpolatedStringNode
-      assert_completion('require "', include: 'set')
-      assert_completion('require "s', include: 'et')
+      # Should not complete terminated string
+      assert_nil ReplTypeCompletor.analyze('require "s"', binding: empty_binding)
+      assert_nil ReplTypeCompletor.analyze('require ?s', binding: empty_binding)
     end
 
     def test_method_block_sym

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -681,6 +681,7 @@ module TestReplTypeCompletor
 
     def test_block_args
       assert_call('[1,2,3].tap{|a| a.', include: Array)
+      assert_call('[1,2,3].tap{|a,| a.', include: Integer)
       assert_call('[1,2,3].tap{|a,b| a.', include: Integer)
       assert_call('[1,2,3].tap{|(a,b)| a.', include: Integer)
       assert_call('[1,2,3].tap{|a,*b| b.', include: Array)

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -333,8 +333,15 @@ module TestReplTypeCompletor
       assert_call('a, ((b=1).c, d) = 1; b.', include: Integer)
       assert_call('a, b[c=1] = 1; c.', include: Integer)
       assert_call('a, b[*(c=1)] = 1; c.', include: Integer)
+      assert_call('a, b[**(c=1)] = 1; c.', include: Integer)
+      assert_call('a, b[&(c=1)] = 1; c.', include: Integer)
+      assert_call('a, b[] = 1; a.', include: Integer)
+      assert_call('def f(*); a, b[*] = 1; a.', include: Integer)
+      assert_call('def f(&); a, b[&] = 1; a.', include: Integer)
+      assert_call('def f(**); a, b[**] = 1; a.', include: Integer)
       # incomplete massign
       assert_analyze_type('a,b', :lvar_or_method, 'b')
+      assert_call('(a=1).b, a.a', include: Integer)
       assert_call('(a=1).b, a.', include: Integer)
       assert_call('a=1; *a.', include: Integer)
     end
@@ -575,6 +582,7 @@ module TestReplTypeCompletor
       assert_call('for *,(*) in [1,2,3]; 1.', include: Integer)
       assert_call('for *i in [1,2,3]; i.sample.', include: Integer)
       assert_call('for (a=1).b in [1,2,3]; a.', include: Integer)
+      assert_call('for a[b=1] in [1,2,3]; b.', include: Integer)
       assert_call('for Array::B in [1,2,3]; Array::B.', include: Integer)
       assert_call('for A in [1,2,3]; A.', include: Integer)
       assert_call('for $a in [1,2,3]; $a.', include: Integer)


### PR DESCRIPTION
Remove StringNode workaround
Simplify CallNode attribute assign check (`CallNode#attribute_write?` is added)
Fix for added nodes `NumberedParametersNode` `CallTargetNode` `IndexTargetNode` `ImplicitRestNode`

