### PR TITLE
Complete keyword arguments

### DIFF
--- a/lib/repl_type_completor/result.rb
+++ b/lib/repl_type_completor/result.rb
@@ -67,8 +67,9 @@ module ReplTypeCompletor
         Symbol.all_symbols.map { _1.inspect[1..] }
       in [:call, name, type, self_call]
         (self_call ? type.all_methods : type.methods).map(&:to_s) - HIDDEN_METHODS
-      in [:lvar_or_method, name, scope]
-        scope.self_type.all_methods.map(&:to_s) | scope.local_variables | RESERVED_WORDS
+      in [:lvar_or_method, name, scope, kwarg_call]
+        kwargs = kwarg_call ? Types.method_kwargs_names(*kwarg_call).map { "#{_1}:" } : []
+        scope.self_type.all_methods.map(&:to_s) | scope.local_variables | kwargs | RESERVED_WORDS
       else
         []
       end
@@ -99,7 +100,7 @@ module ReplTypeCompletor
         value_doc scope[prefix + matched]
       in [:call, prefix, type, _self_call]
         method_doc type, prefix + matched
-      in [:lvar_or_method, prefix, scope]
+      in [:lvar_or_method, prefix, scope, kwarg_call]
         if scope.local_variables.include?(prefix + matched)
           value_doc scope[prefix + matched]
         else

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -92,6 +92,23 @@ module TestReplTypeCompletor
       assert_doc_namespace('lvar = ""; lvar.ascii_only?', 'String#ascii_only?', binding: bind)
     end
 
+    def test_kwarg
+      o = Object.new; def o.foo(bar:, baz: true); end
+      m = Module.new; def m.foo(foobar:, foobaz: true); end
+      bind = binding
+      # kwarg name from method.parameters
+      assert_completion('o.foo ba', binding: bind, include: ['r:', 'z:'])
+      assert_completion('m.foo fo', binding: bind, include: ['obar:', 'obaz:'])
+      assert_completion('foo ba', binding: o.instance_eval { binding }, include: ['r:', 'z:'])
+      assert_completion('foo fo', binding: m.instance_eval { binding }, include: ['obar:', 'obaz:'])
+      # kwarg name from RBS
+      assert_completion('"".each_line ch', binding: bind, include: 'omp:')
+      assert_completion('String.new en', binding: bind, include: 'coding:')
+      # assert completion when kwarg name is not found
+      assert_completion('o.inspect ra', binding: bind, include: 'nd')
+      assert_completion('o.undefined_method ra', binding: bind, include: 'nd')
+    end
+
     def test_const
       assert_completion('Ar', include: 'ray')
       assert_completion('::Ar', include: 'ray')

--- a/test/repl_type_completor/test_types.rb
+++ b/test/repl_type_completor/test_types.rb
@@ -96,5 +96,19 @@ module TestReplTypeCompletor
       type = ReplTypeCompletor::Types.type_from_object bo
       assert type.all_methods.include?(:foobar)
     end
+
+    def test_kwargs_names
+      bo = BasicObject.new
+      def bo.foobar(bo_kwarg1: nil, bo_kwarg2:); end
+      bo_type = ReplTypeCompletor::Types.type_from_object bo
+      assert_equal %i[bo_kwarg1 bo_kwarg2], ReplTypeCompletor::Types.method_kwargs_names(bo_type, :foobar)
+      str_type = ReplTypeCompletor::Types::STRING
+      assert_include ReplTypeCompletor::Types.method_kwargs_names(str_type, :each_line), :chomp
+      singleton_type = ReplTypeCompletor::Types::SingletonType.new String
+      assert_include ReplTypeCompletor::Types.method_kwargs_names(singleton_type, :new), :encoding
+      union_type = ReplTypeCompletor::Types::UnionType[bo_type, str_type, singleton_type]
+      assert_include ReplTypeCompletor::Types.method_kwargs_names(union_type, :each_line), :chomp
+      assert_equal ReplTypeCompletor::Types.method_kwargs_names(str_type, :undefined_method), []
+    end
   end
 end


### PR DESCRIPTION
![kwarg](https://github.com/ruby/repl_type_completor/assets/1780201/69468b60-604a-4c99-bf4d-6226cb9c27ba)


For `obj.foo ba`, `ba` can be an lvar, method or keyword that starts with `ba`.
We need to check two things, type of `obj` and scope at `ba` in a single analyze.
Completion candidates will be:
- keyword arguments names of `obj.foo` 
- local variables in scope at `ba`
- methods of `self` in scope at `ba`

To do it, `ReplTypeCompletion::TypeAnalyze::DigTargets` is changed.
```ruby
# This class is used to check if the node is analyze target, and to skip analyze for some node.
# For `def f;long_code;end; def g; 1.a`, `def f` is skipped, `1` is target_node.

# Only single target_node
DigTargets.new(parent_nodes_to_analyze, target_node){
  callback_when_analyzed_target_node
}
# ↓
# Multiple target nodes
dig_targets = DigTargets.new(parent_nodes_to_analyze)
dig_targets.on(node1){callback1}
dig_targets.on(node2){callback2}
```