### PR TITLE
Dedupe require paths completion

### DIFF
--- a/test/repl_type_completor/test_require_paths.rb
+++ b/test/repl_type_completor/test_require_paths.rb
@@ -2,6 +2,7 @@
 
 require 'repl_type_completor'
 require_relative './helper'
+require 'tmpdir'
 
 module TestReplTypeCompletor
   class RequirePathsTest < TestCase
@@ -21,6 +22,49 @@ module TestReplTypeCompletor
       assert_include ReplTypeCompletor::RequirePaths.require_relative_completions('li', project_root), 'lib/repl_type_completor/'
       assert_not_include ReplTypeCompletor::RequirePaths.require_relative_completions('li', project_root), 'lib/repl_type_completor/version'
       assert_include ReplTypeCompletor::RequirePaths.require_relative_completions('lib/', project_root), 'lib/repl_type_completor/version'
+    end
+
+    def clear_cache
+      ReplTypeCompletor::RequirePaths.instance_eval do
+        remove_instance_variable(:@gem_and_system_load_paths) if defined? @gem_and_system_load_paths
+        remove_instance_variable(:@cache) if defined? @cache
+      end
+    end
+
+    def test_require_paths_no_duplication
+      # When base_dir/ base_dir/3.3.0 base_dir/3.3.0/arm64-darwin are in $LOAD_PATH,
+      # "3.3.0/arm64-darwin/file", "arm64-darwin/file" and "file" will all require the same file.
+      # Completion candidates should only include the shortest one.
+      load_path_backup = $LOAD_PATH.dup
+      dir0 = Dir.mktmpdir
+      dir1 = File.join(dir0, '3.3.0')
+      dir2 = File.join(dir1, 'arm64-darwin')
+      dir3 = File.join(dir1, 'test_req_dir')
+      Dir.mkdir dir1
+      Dir.mkdir dir2
+      Dir.mkdir dir3
+      File.write File.join(dir0, 'test_require_a.rb'), ''
+      File.write File.join(dir1, 'test_require_a.rb'), ''
+      File.write File.join(dir2, 'test_require_a.rb'), ''
+      File.write File.join(dir0, 'test_require_b.rb'), ''
+      File.write File.join(dir1, 'test_require_c.rb'), ''
+      File.write File.join(dir1, 'arm64-darwin-foobar.rb'), ''
+      File.write File.join(dir2, 'test_require_d.rb'), ''
+      File.write File.join(dir3, 'test_require_e.rb'), ''
+      $LOAD_PATH.push(dir0, dir1, dir2)
+      clear_cache
+
+      files = %w[test_req_dir/test_require_e test_require_a test_require_b test_require_c test_require_d]
+      assert_equal files, ReplTypeCompletor::RequirePaths.require_completions('test_req').sort
+      candidates = ReplTypeCompletor::RequirePaths.require_completions('')
+      assert_include candidates, 'arm64-darwin-foobar'
+      files.each do |path|
+        assert_not_include candidates, "3.3.0/#{path}"
+        assert_not_include candidates, "3.3.0/arm64-darwin/#{path}"
+        assert_not_include candidates, "arm64-darwin/#{path}"
+      end
+    ensure
+      $LOAD_PATH.replace load_path_backup
     end
   end
 end


### PR DESCRIPTION
Fix this duplicated candidates
![スクリーンショット 2023-12-04 3 58 42](https://github.com/ruby/repl_type_completor/assets/1780201/e2182f2f-720b-4a7e-9320-db167a5c7846)
And remove these require paths
![スクリーンショット 2023-12-05 21 09 27](https://github.com/ruby/repl_type_completor/assets/1780201/73fcf0e4-6f4a-4899-9e10-e8cc36c5fd32)

Sometimes, there are duplicated gem paths in `Gem::Specification.latest_specs(true)` and `$LOAD_PATH`.
```
~/.rbenv/versions/3.2.2/lib/ruby/3.2.0/irb
~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.10.0
```

When `$LOAD_PATH` have paths like this
```
"~/.rbenv/versions/3.2.2/lib/ruby/3.2.0"
"~/.rbenv/versions/3.2.2/lib/ruby/3.2.0/arm64-darwin22"
```
File `~/.rbenv/versions/3.2.2/lib/ruby/3.2.0/arm64-darwin22/foo.bundle` can be required by both `require 'foo'` and `require 'arm64-darwin22/foo'`. This pull request removes the longer path and only complete shorest path.

