### PR TITLE
Do not completion `foo()bar` `:"foo"bar`

### DIFF
--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -81,6 +81,8 @@ module ReplTypeCompletor
           [:require_relative, content]
         end
       when Prism::SymbolNode
+        return unless !target_node.closing || target_node.empty?
+
         name = target_node.value.to_s
         if parents.last.is_a? Prism::BlockArgumentNode # method(&:target)
           receiver_type, _scope = calculate_type_scope.call target_node
@@ -89,6 +91,8 @@ module ReplTypeCompletor
           [:symbol, name] unless name.empty?
         end
       when Prism::CallNode
+        return if target_node.opening
+
         name = target_node.message.to_s
         return [:lvar_or_method, name, calculate_scope.call] if target_node.receiver.nil?
 

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -64,6 +64,13 @@ module TestReplTypeCompletor
       assert_doc_namespace('Object::rand', 'Object.rand')
     end
 
+    def test_closed_no_completion
+      # `:"bin"` should not complete `:"bin"ding`
+      assert_nil(ReplTypeCompletor.analyze(':"bin"', binding: binding))
+      # `ex()` should not complete `ex()it`
+      assert_nil(ReplTypeCompletor.analyze('ex()', binding: binding))
+    end
+
     def test_lvar
       bind = eval('lvar = 1; binding')
       assert_completion('lva', binding: bind, include: 'r')


### PR DESCRIPTION
Fix these wrong completion
`ex()` completes `ex()it`
`:"ex"` completes `:"ex"ception`