### PR TITLE
Fix anonymous class doc_namespace to use named superclass

### DIFF
--- a/lib/repl_type_completor/result.rb
+++ b/lib/repl_type_completor/result.rb
@@ -139,18 +139,26 @@ module ReplTypeCompletor
       type = type.types.find { _1.all_methods.include? name.to_sym }
       case type
       when Types::SingletonType
-        "#{Types.class_name_of(type.module_or_class)}.#{name}"
+        "#{doc_class_module_name(type.module_or_class)}.#{name}"
       when Types::InstanceType
-        "#{Types.class_name_of(type.klass)}##{name}"
+        "#{doc_class_module_name(type.klass)}##{name}"
       end
     end
 
     def call_or_const_doc(type, name)
       if name =~ /\A[A-Z]/
         type = type.types.grep(Types::SingletonType).find { _1.module_or_class.const_defined?(name) }
-        type.module_or_class == Object ? name : "#{Types.class_name_of(type.module_or_class)}::#{name}" if type
+        type.module_or_class == Object ? name : "#{doc_class_module_name(type.module_or_class)}::#{name}" if type
       else
         method_doc(type, name)
+      end
+    end
+
+    def doc_class_module_name(module_or_class)
+      if Class === module_or_class
+        Types.class_name_of(module_or_class)
+      else
+        Methods::MODULE_NAME_METHOD.bind_call(module_or_class) || 'Module'
       end
     end
 
@@ -159,9 +167,9 @@ module ReplTypeCompletor
       type.types.each do |t|
         case t
         when Types::SingletonType
-          return Types.class_name_of(t.module_or_class)
+          return doc_class_module_name(t.module_or_class)
         when Types::InstanceType
-          return Types.class_name_of(t.klass)
+          return doc_class_module_name(t.klass)
         end
       end
       nil

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -183,6 +183,20 @@ module TestReplTypeCompletor
       end
     end
 
+    def test_anonymous_class
+      bind = eval('c = Struct.new(:foobar); o = c.new; binding')
+      assert_completion('c.', binding: bind, include: ['ancestors', 'singleton_class?', 'superclass'])
+      assert_completion('o.', binding: bind, include: ['foobar', 'each_pair'])
+      assert_doc_namespace('c.superclass', 'Struct.superclass', binding: bind)
+      assert_doc_namespace('o.each', 'Struct#each', binding: bind)
+    end
+
+    def test_anonymous_module
+      bind = eval('m = Module.new; binding')
+      assert_completion('m.', binding: bind, include: ['ancestors', 'singleton_class?'], exclude: 'superclass')
+      assert_doc_namespace('m.ancestors', 'Module.ancestors', binding: bind)
+    end
+
     DEPRECATED_CONST = 1
     deprecate_constant :DEPRECATED_CONST
     def test_deprecated_const_without_warning


### PR DESCRIPTION
Showing document for a instance of anonymous class is slow
```ruby
irb(main):001> s = Struct.new(:foo).new
irb(main):002> s.ins[TAB]
```
It's because doc_namespace returned `'#inspect'` instead of `KLASS_NAME#inspect`. RDoc seems to search every class that has method `inspect`.

Changed to search for superclass that has a name.

The same problem also exists in IRB's RegexpCompletor.


