### PR TITLE
Fix lambda with numbered parameter error

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -439,7 +439,12 @@ module ReplTypeCompletor
 
       block_scope = Scope.new scope, { **local_table, Scope::BREAK_RESULT => nil, Scope::NEXT_RESULT => nil, Scope::RETURN_RESULT => nil }
       block_scope.conditional do |s|
-        assign_parameters node.parameters.parameters, s, [], {} if node.parameters.is_a?(Prism::ParametersNode) && node.parameters.parameters
+        case node.parameters
+        when Prism::NumberedParametersNode
+          assign_numbered_parameters node.parameters.maximum, s, [Types::OBJECT] * node.parameters.maximum, {}
+        when Prism::BlockParametersNode
+          assign_parameters node.parameters.parameters, s, [], {} if node.parameters.parameters
+        end
         evaluate node.body, s if node.body
       end
       block_scope.merge_jumps

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -694,6 +694,15 @@ module TestReplTypeCompletor
       assert_call('f((x=1)=>1); x.', include: Integer)
     end
 
+    def test_lambda_args
+      assert_call('->(*a){a.', include: Array)
+      assert_call('->(**a){a.', include: Hash)
+      assert_call('->(a=1){a.', include: Integer)
+      assert_call('->a{a.', include: Object)
+      assert_call('->(){1.', include: Integer)
+      assert_call('->{_1.', include: Object)
+    end
+
     def test_block_args
       assert_call('[1,2,3].tap{|a| a.', include: Array)
       assert_call('[1,2,3].tap{|a,| a.', include: Integer)


### PR DESCRIPTION
Fix bug that fails to analyze code includeing `->{_1}`

```ruby
ReplTypeCompletor.analyze("->{_1}; 1.", binding:) #=> nil
```
