### PR TITLE
Update required prism version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        prism: ['latest', '0.20.0', '0.19.0']
+        prism: ['latest', '0.23.0', '0.21.0', '0.19.0']
     env:
       GEMFILE_PRISM_VERSION: ${{ matrix.prism }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rbs: ['latest', '3.0', '2.7.0']
+        rbs: ['latest', '3.4', '3.2', '3.0', '2.7.0']
     env:
       GEMFILE_RBS_VERSION: ${{ matrix.rbs }}
     steps:

--- a/repl_type_completor.gemspec
+++ b/repl_type_completor.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "prism", ">= 0.19.0", "< 0.21.0"
+  spec.add_dependency "prism", ">= 0.19.0", "< 0.24.0"
   spec.add_dependency "rbs", ">= 2.7.0", "< 4.0.0"
 end


### PR DESCRIPTION
Skipped prism 0.20.0(8590 downloads) and 0.22.0(3327 downloads), Add 0.21.0(61852 downloads)