### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Change from 0.1.2:
Required prism version is `< 0.20.0` → `< 0.24.0`