### PR TITLE
Fix empty block args bug `tap{||}`

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -269,7 +269,9 @@ module ReplTypeCompletor
               when Prism::NumberedParametersNode
                 assign_numbered_parameters node.block.parameters.maximum, block_scope, block_args, {}
               when Prism::BlockParametersNode
-                assign_parameters node.block.parameters.parameters, block_scope, block_args, {}
+                if node.block.parameters.parameters
+                  assign_parameters node.block.parameters.parameters, block_scope, block_args, {}
+                end
               end
               result = node.block.body ? evaluate(node.block.body, block_scope) : Types::NIL
               block_scope.merge_jumps

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -701,6 +701,7 @@ module TestReplTypeCompletor
     end
 
     def test_block_args
+      assert_call('[1,2,3].tap{|| 1.', include: Integer)
       assert_call('[1,2,3].tap{|a| a.', include: Array)
       assert_call('[1,2,3].tap{|a,| a.', include: Integer)
       assert_call('[1,2,3].tap{|a,b| a.', include: Integer)


### PR DESCRIPTION
`BlockParametersNode#parameters` can be nil for `tap{||}`. Added nil check for this.
```
# tap{||}
@ BlockNode (location: (1,3)-(1,7))
├── locals: []
├── parameters:
│   @ BlockParametersNode (location: (1,4)-(1,6))
│   ├── parameters: ∅ # ← This part
│   ├── locals: (length: 0)
│   ├── opening_loc: (1,4)-(1,5) = "|"
│   └── closing_loc: (1,5)-(1,6) = "|"
├── body: ∅
├── opening_loc: (1,3)-(1,4) = "{"
└── closing_loc: (1,6)-(1,7) = "}",
```

```
# tap{}
@ BlockNode (location: (1,3)-(1,5))
├── locals: []
├── parameters: ∅
├── body: ∅
├── opening_loc: (1,3)-(1,4) = "{"
└── closing_loc: (1,4)-(1,5) = "}",
```