### PR TITLE
Remove supporting `a[&b]=c` `a[**b]=c` because it is removed in ruby 3.4

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -824,7 +824,7 @@ module ReplTypeCompletor
     def evaluate_call_node_arguments(call_node, scope)
       # call_node.arguments is Prism::ArgumentsNode
       arguments = call_node.arguments&.arguments&.dup || []
-      block_arg = call_node.block.expression if call_node.block.is_a?(Prism::BlockArgumentNode)
+      block_arg = call_node.block.expression if call_node.respond_to?(:block) && call_node.block.is_a?(Prism::BlockArgumentNode)
       kwargs = arguments.pop.elements if arguments.last.is_a?(Prism::KeywordHashNode)
       args_types = arguments.map do |arg|
         case arg
@@ -1100,7 +1100,6 @@ module ReplTypeCompletor
             end
           end
         end
-        evaluate node.block.expression, scope if node.block&.expression
         receiver
       when Prism::SplatNode
         evaluate_multi_write_receiver node.expression, scope, evaluated_receivers if node.expression

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -337,12 +337,8 @@ module TestReplTypeCompletor
       assert_call('a, ((b=1).c, d) = 1; b.', include: Integer)
       assert_call('a, b[c=1] = 1; c.', include: Integer)
       assert_call('a, b[*(c=1)] = 1; c.', include: Integer)
-      assert_call('a, b[**(c=1)] = 1; c.', include: Integer)
-      assert_call('a, b[&(c=1)] = 1; c.', include: Integer)
       assert_call('a, b[] = 1; a.', include: Integer)
       assert_call('def f(*); a, b[*] = 1; a.', include: Integer)
-      assert_call('def f(&); a, b[&] = 1; a.', include: Integer)
-      assert_call('def f(**); a, b[**] = 1; a.', include: Integer)
       # incomplete massign
       assert_analyze_type('a,b', :lvar_or_method, 'b')
       assert_call('(a=1).b, a.a', include: Integer)
@@ -518,9 +514,6 @@ module TestReplTypeCompletor
       assert_call('END{1.', include: Integer)
       # MatchWrite
       assert_call('a=1; /(?<a>)/=~b; a.', include: [String, NilClass], exclude: Integer)
-      # OperatorWrite with block `a[&b]+=c`
-      assert_call('a=[1]; (a[0,&:to_a]+=1.0).', include: Float)
-      assert_call('a=[1]; (a[0,&b]+=1.0).', include: Float)
     end
 
     def test_hash


### PR DESCRIPTION
These codes are not permitted in ruby 3.4
```ruby
a[&b]=1
a[x:1]=1
a[&b],a[x:1]=1,2
```

Remove code and test that supports these syntax, Don't call `IndexTargetNode#block` if method block does not exist (perhaps disappear in the future)