### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Changes
- Update required prism version
- Pattern match bugfix

Diff: https://github.com/ruby/repl_type_completor/compare/v0.1.3...6a82c06c4a19491245d0c20cd11d393d3e2c579e
