### PR TITLE
Remove required max prism version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        prism: ['latest', '0.25.0', '0.24.0', '0.21.0', '0.19.0']
+        prism: ['latest', '0.27.0', '0.24.0', '0.21.0', '0.19.0']
     env:
       GEMFILE_PRISM_VERSION: ${{ matrix.prism }}
     steps:

--- a/repl_type_completor.gemspec
+++ b/repl_type_completor.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "prism", ">= 0.19.0", "< 0.26.0"
+  spec.add_dependency "prism", ">= 0.19.0"
   spec.add_dependency "rbs", ">= 2.7.0", "< 4.0.0"
 end


### PR DESCRIPTION
Prism API is not drastically changed since 0.19.0 which is bundled in ruby 3.3.0.
Release cycle of repl_type_completor is infrequent than prism
I think we can remove max version
