### PR TITLE
Catchup with ConstantPathNode change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        prism: ['latest', '0.27.0', '0.24.0', '0.21.0', '0.19.0']
+        prism: ['latest', '0.28.0', '0.27.0', '0.24.0', '0.21.0', '0.19.0']
     env:
       GEMFILE_PRISM_VERSION: ${{ matrix.prism }}
     steps:

--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -101,6 +101,15 @@ module ReplTypeCompletor
         [op == '::' ? :call_or_const : :call, name, receiver_type, self_call]
       when Prism::LocalVariableReadNode, Prism::LocalVariableTargetNode
         [:lvar_or_method, target_node.name.to_s, calculate_scope.call]
+      when Prism::ConstantPathNode
+        name = target_node.name.to_s
+        if target_node.parent # A::B
+          receiver, scope = calculate_type_scope.call(target_node.parent)
+          [:const, name, receiver, scope]
+        else # ::A
+          scope = calculate_scope.call
+          [:const, name, Types::SingletonType.new(Object), scope]
+        end
       when Prism::ConstantReadNode, Prism::ConstantTargetNode
         name = target_node.name.to_s
         if parents.last.is_a? Prism::ConstantPathNode

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -419,7 +419,8 @@ module ReplTypeCompletor
     def evaluate_constant_path_write_node(node, scope)
       receiver = evaluate node.target.parent, scope if node.target.parent
       value = evaluate node.value, scope
-      const_path_write receiver, node.target.child.name.to_s, value, scope
+      name = node.target.respond_to?(:name) ? node.target.name.to_s : node.target.child.name.to_s
+      const_path_write receiver, name, value, scope
       value
     end
 
@@ -871,7 +872,7 @@ module ReplTypeCompletor
     def evaluate_constant_node_info(node, scope)
       case node
       when Prism::ConstantPathNode
-        name = node.child.name.to_s
+        name = node.respond_to?(:name) ? node.name.to_s : node.child.name.to_s
         if node.parent
           receiver = evaluate node.parent, scope
           if receiver.is_a? Types::SingletonType
@@ -1042,7 +1043,8 @@ module ReplTypeCompletor
         scope[node.name.to_s] = value
       when Prism::ConstantPathTargetNode
         receiver = evaluated_receivers&.[](node.parent) || evaluate(node.parent, scope) if node.parent
-        const_path_write receiver, node.child.name.to_s, value, scope
+        name = node.respond_to?(:name) ? node.name.to_s : node.child.name.to_s
+        const_path_write receiver, name, value, scope
       end
     end
 

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -419,7 +419,7 @@ module ReplTypeCompletor
     def evaluate_constant_path_write_node(node, scope)
       receiver = evaluate node.target.parent, scope if node.target.parent
       value = evaluate node.value, scope
-      name = node.target.respond_to?(:name) ? node.target.name.to_s : node.target.child.name.to_s
+      name = const_path_name(node.target)
       const_path_write receiver, name, value, scope
       value
     end
@@ -844,6 +844,16 @@ module ReplTypeCompletor
       [args_types, kwargs_types, block_sym_node, !!block_arg]
     end
 
+    def const_path_name(node)
+      if node.respond_to?(:name)
+        # ConstantPathNode#name ConstantPathTargetNode#name is added in Prism 0.28.0
+        node.name.to_s
+      else
+        # ConstantPathNode#child ConstantPathTargetNode#child is deprecated in Prism 0.28.0
+        node.child.name.to_s
+      end
+    end
+
     def const_path_write(receiver, name, value, scope)
       if receiver # receiver::A = value
         singleton_type = receiver.types.find { _1.is_a? Types::SingletonType }
@@ -872,7 +882,7 @@ module ReplTypeCompletor
     def evaluate_constant_node_info(node, scope)
       case node
       when Prism::ConstantPathNode
-        name = node.respond_to?(:name) ? node.name.to_s : node.child.name.to_s
+        name = const_path_name(node)
         if node.parent
           receiver = evaluate node.parent, scope
           if receiver.is_a? Types::SingletonType
@@ -1043,7 +1053,7 @@ module ReplTypeCompletor
         scope[node.name.to_s] = value
       when Prism::ConstantPathTargetNode
         receiver = evaluated_receivers&.[](node.parent) || evaluate(node.parent, scope) if node.parent
-        name = node.respond_to?(:name) ? node.name.to_s : node.child.name.to_s
+        name = const_path_name(node)
         const_path_write receiver, name, value, scope
       end
     end


### PR DESCRIPTION
In prism-0.28.0, ConstantPathNode#child is deprecated
```ruby
Prism.parse('A::B').value.statements.body.first.child
# DEPRECATED: ConstantPathNode#child is deprecated and will be removed in the next major version. Use ConstantPathNode#name/ConstantPathNode#name_loc instead. Called from (irb):1:in `<top (required)>'.
=> 
@ ConstantReadNode (location: (1,3)-(1,4))
└── name: :B
```
And ConstantPathNode#child does not appear in child_nodes anymore.
```ruby
Prism.parse('A::B').value.statements.body.first.child_nodes
=>
[@ ConstantReadNode (location: (1,0)-(1,1))
 └── name: :A]

# it was
[@ ConstantReadNode (location: (1,0)-(1,1))
 └── name: :A]
[@ ConstantReadNode (location: (1,3)-(1,4))
 └── name: :B]
```
So completion target node search for constant path completion is failing now. This pull request fixes it.
