### PR TITLE
Fix rescue_node reference evaluation

### DIFF
--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -101,7 +101,7 @@ module ReplTypeCompletor
         [op == '::' ? :call_or_const : :call, name, receiver_type, self_call]
       when Prism::LocalVariableReadNode, Prism::LocalVariableTargetNode
         [:lvar_or_method, target_node.name.to_s, calculate_scope.call]
-      when Prism::ConstantPathNode
+      when Prism::ConstantPathNode, Prism::ConstantPathTargetNode
         name = target_node.name.to_s
         if target_node.parent # A::B
           receiver, scope = calculate_type_scope.call(target_node.parent)

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -579,12 +579,7 @@ module ReplTypeCompletor
           end
           error_types << Types::InstanceType.new(StandardError) if error_types.empty?
           error_type = Types::UnionType[*error_types]
-          case node.reference
-          when Prism::LocalVariableTargetNode, Prism::InstanceVariableTargetNode, Prism::ClassVariableTargetNode, Prism::GlobalVariableTargetNode, Prism::ConstantTargetNode
-            s[node.reference.name.to_s] = error_type
-          when Prism::CallTargetNode, Prism::IndexTargetNode
-            evaluate_multi_write_receiver node.reference, s, nil
-          end
+          evaluate_write node.reference, error_type, s, nil
         end
         node.statements ? evaluate(node.statements, s) : Types::NIL
       end

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -74,7 +74,11 @@ module TestReplTypeCompletor
       assert_equal [:ivar, '@a'], analyze('begin; rescue => @a')[0, 2]
       assert_equal [:cvar, '@@a'], analyze('begin; rescue => @@a')[0, 2]
       assert_equal [:const, 'A'], analyze('begin; rescue => A')[0, 2]
+      assert_equal [:const, 'B'], analyze('begin; rescue => A::B')[0, 2]
       assert_equal [:call, 'b'], analyze('begin; rescue => a.b')[0, 2]
+      assert_call 'begin; rescue => (a=1)::B; a.', include: Integer
+      assert_call 'begin; rescue => A; A.', include: StandardError
+      assert_call 'begin; rescue => Array::A; Array::A.', include: StandardError
     end
 
     def test_ref


### PR DESCRIPTION
Fix type evaluation bug when ConstantPathTargetNode is placed in rescue reference.
```ruby
begin; rescue => Foo::Ba # [completion of Foo::Bar does not work]

# Need for writing this code
begin; rescue => Foo::Bar.attr; end
```
