### PR TITLE
Support instance method returning instance type

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -332,6 +332,8 @@ module ReplTypeCompletor
         self_type.transform do |type|
           if type.is_a?(SingletonType) && type.module_or_class.is_a?(Class)
             InstanceType.new type.module_or_class
+          elsif type.is_a?(InstanceType)
+            InstanceType.new type.klass
           else
             OBJECT
           end

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -719,5 +719,10 @@ module TestReplTypeCompletor
       # Proc#call `(?) -> untyped` is RBS::Types::UntypedFunction
       assert_call('proc{}.call; 1.', include: Integer)
     end
+
+    def test_rbs_instance_type
+      assert_call('Thread.start{}.', include: Thread)
+      assert_call('"".encode("utf-8").', include: String)
+    end
   end
 end


### PR DESCRIPTION
`"".encode.` was showing `Object.methods`.
Fix it to show `String.methods`.
