### PR TITLE
Fix test failed in latest rbs

### DIFF
--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -152,7 +152,7 @@ module TestReplTypeCompletor
     def test_union_splat
       assert_call('a, = [[:a], 1, nil].sample; a.', include: [Symbol, Integer, NilClass], exclude: Object)
       assert_call('[[:a], 1, nil].each do _2; _1.', include: [Symbol, Integer, NilClass], exclude: Object)
-      assert_call('a = [[:a], 1, nil, ("a".."b")].sample; [*a].sample.', include: [Symbol, Integer, NilClass, String], exclude: Object)
+      assert_call('a = [[:a], 1, ("a".."b")].sample; [*a].sample.', include: [Symbol, Integer, String], exclude: Object)
     end
 
     def test_range


### PR DESCRIPTION
Failed reason: `Array#sample` is changed from `-> Elem?` to `-> Elem`
