### PR TITLE
Require rbs outside of thread to avoid deadlock

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rbs'
+require 'rbs/cli'
 require_relative 'methods'
 
 module ReplTypeCompletor
@@ -22,8 +24,6 @@ module ReplTypeCompletor
 
     def self.load_rbs_builder
       @load_started = true
-      require 'rbs'
-      require 'rbs/cli'
       loader = RBS::CLI::LibraryOptions.new.loader
       loader.add path: Pathname('sig')
       @rbs_builder = RBS::DefinitionBuilder.new env: RBS::Environment.from_loader(loader).resolve_type_names


### PR DESCRIPTION
IRB's debug command stops all threads. When thread which is running `require 'rbs'` stops, all require will be blocked forever because `require` has exclusive control.
In IRB, pressing TAB will start `require 'rdoc'` but it will deadlock if debug mode started before `require 'rbs'` completes.

To avoid it, all `require` should be done in main thread.
This will make IRB startup time slow about 43%.
```
# Benchmarks

PTY.spawn('irb', '--regexp-completor').first.getc
# processing time: 0.168581s

PTY.spawn('irb', '--type-completor').first.getc # main branch
# processing time: 0.189315s

PTY.spawn('irb', '--type-completor').first.getc # this branch
# processing time: 0.271634s
```
