### PR TITLE
Loads rbs defined in gem sig directory

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -236,6 +236,13 @@ module TestReplTypeCompletor
       ReplTypeCompletor.instance_variable_set(:@last_completion_error, nil)
     end
 
+    def test_loaded_gem_types
+      result = ReplTypeCompletor.analyze 'Prism.parse("code").', binding: binding
+      candidtes = result.completion_candidates
+      assert_includes candidtes, 'success?'
+      assert_includes candidtes, 'failure?'
+    end
+
     def test_info
       assert_equal "ReplTypeCompletor: #{ReplTypeCompletor::VERSION}, Prism: #{Prism::VERSION}, RBS: #{RBS::VERSION}", ReplTypeCompletor.info
     end


### PR DESCRIPTION
Some gem have rbs files in sig directory. The number of gems including sig directory will increase.
ReplTypeCompletor will search `Gem.loaded_specs` and loads gem's sig directory.

```ruby
require 'rmagick'
binding.irb

irb(main):001* Magick.fonts.map(&:w█
                                 :weight 
                                 :weight=
```

## Restriction
ReplTypeCompletor loads type information from a gem that is already loaded before first `binding.irb`.
`require '[gem_name]'` after that, types are not loaded.
```
require 'foo'
binding.irb
# Loads rbs from gem foo.
irb(main):001> require 'bar'
true
# Doesn't load rbs from gem bar.
irb(main):002>
```
#32 is a prototype to reload RBS after new gem is loaded.
