### PR TITLE
Support it parameter

### DIFF
--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -101,6 +101,8 @@ module ReplTypeCompletor
         [op == '::' ? :call_or_const : :call, name, receiver_type, self_call]
       when Prism::LocalVariableReadNode, Prism::LocalVariableTargetNode
         [:lvar_or_method, target_node.name.to_s, calculate_scope.call]
+      when Prism::ItLocalVariableReadNode
+        [:lvar_or_method, 'it', calculate_scope.call]
       when Prism::ConstantPathNode, Prism::ConstantPathTargetNode
         name = target_node.name.to_s
         if target_node.parent # A::B
@@ -122,8 +124,8 @@ module ReplTypeCompletor
     end
 
     def find_target(node, position)
-      # Skip because NumberedParametersNode#location gives location of whole block
-      return if node.is_a? Prism::NumberedParametersNode
+      # Skip because location of these nodes gives location of whole block
+      return if node.is_a?(Prism::NumberedParametersNode) || node.is_a?(Prism::ItParametersNode)
 
       node.compact_child_nodes.each do |n|
         match = find_target(n, position)

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -230,7 +230,7 @@ module ReplTypeCompletor
     alias evaluate_instance_variable_read_node evaluate_reference_read
 
     def evaluate_it_local_variable_read_node(_node, scope)
-      # `it` is not a normal local variable. It can be overrided like `tap{p it; it=1}`.
+      # `it` is not a normal local variable. It can be overridden like `tap{p it; it=1}`.
       # Use the name `_1` instead of `it` to avoid conflict.
       scope['_1'] || Types::NIL
     end

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -92,6 +92,13 @@ module TestReplTypeCompletor
       assert_doc_namespace('lvar = ""; lvar.ascii_only?', 'String#ascii_only?', binding: bind)
     end
 
+    def test_confusing_lvar_method_it
+      bind = eval('item = 1; ins=1; random = 1; binding')
+      assert_completion('->{it', binding: bind, include: ['em', 'self'])
+      assert_completion('->{ins', binding: bind, include: 'pect')
+      assert_completion('->{rand', binding: bind, include: 'om')
+    end
+
     def test_const
       assert_completion('Ar', include: 'ray')
       assert_completion('::Ar', include: 'ray')

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -552,6 +552,16 @@ module TestReplTypeCompletor
       assert_call('[:a].each_with_index{_2.', include: Integer, exclude: Symbol)
     end
 
+    def test_it_parameter
+      assert_call('->{it.', include: Object, exclude: NilClass)
+      assert_call('->{p it; it=:a; it.', include: Symbol, exclude: Object)
+      assert_call('1.tap{it.', include: Integer)
+      assert_call('1.tap{p it; it=:a; it.', include: Symbol, exclude: Integer)
+      assert_call('[1].tap{it.', include: Array)
+      assert_call('loop{it.', include: NilClass, exclude: Object)
+      assert_call('[:a].each_with_index{it.', include: Symbol, exclude: [Integer, Array])
+    end
+
     def test_if_unless
       assert_call('if cond; 1; end.', include: Integer)
       assert_call('unless true; 1; end.', include: Integer)


### PR DESCRIPTION
If the code includes `it`, calculating completion was failing. This pull request fixes this bug.
```ruby
ReplTypeCompletor.analyze('1.tap { "a".ascii_onl', binding:)
# => #<ReplTypeCompletor::Result:0x00000001245db568 @analyze_result=[:call, "ascii_onl", String, false], @binding=#<Binding:0x0000000126d9afe0>, @source_file=nil>

ReplTypeCompletor.analyze('1.tap { p it; "a".ascii_onl', binding:) # Fails
# => nil
```

And supports completion to `it`.
```ruby
ReplTypeCompletor.analyze('1.tap { it.allbi', binding:)
# => #<ReplTypeCompletor::Result:0x00000001315df8e0 @analyze_result=[:call, "allbi", Integer, false], @binding=#<Binding:0x0000000131791ad0>, @source_file=nil>
```