### PR TITLE
Fix for RBS::Types::UntypedFunction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rbs: ['latest', '3.4', '3.2', '3.0', '2.7.0']
+        rbs: ['latest', '3.6', '3.4', '3.2', '3.0', '2.7.0']
     env:
       GEMFILE_RBS_VERSION: ${{ matrix.rbs }}
     steps:

--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -1145,7 +1145,7 @@ module ReplTypeCompletor
         receiver_vars = receiver.is_a?(Types::InstanceType) ? receiver.params : {}
         free_vars = method.type.free_variables - receiver_vars.keys.to_set
         vars = receiver_vars.merge Types.match_free_variables(free_vars, method_params, given_params)
-        if block && method.block
+        if block && method.block && method.block.type.respond_to?(:required_positionals)
           params_type = method.block.type.required_positionals.map do |func_param|
             Types.from_rbs_type func_param.type, receiver, vars
           end

--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -83,7 +83,9 @@ module ReplTypeCompletor
       methods_with_score = receivers.flat_map do |receiver_type, klass, singleton|
         method = rbs_search_method klass, method_name, singleton
         next [] unless method
-        method.method_types.map do |method_type|
+        method.method_types.filter_map do |method_type|
+          next unless method_type.type.respond_to?(:required_positionals)
+
           score = 0
           score += 2 if !!method_type.block == has_block
           reqs = method_type.type.required_positionals

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -13,7 +13,7 @@ module TestReplTypeCompletor
       end
       ReplTypeCompletor::Types.load_rbs_builder unless ReplTypeCompletor::Types.rbs_builder
     end
-    
+
     def teardown
       ReplTypeCompletor.singleton_class.remove_method(:handle_exception)
       ReplTypeCompletor.define_singleton_method(:handle_exception, &@handle_exception_method)
@@ -710,6 +710,14 @@ module TestReplTypeCompletor
       assert_call('[1][0].', include: Integer, exclude: [Array, NilClass])
       assert_call('[1].[](0).', include: Integer, exclude: [Array, NilClass])
       assert_call('[1].[](0){}.', include: Integer, exclude: [Array, NilClass])
+    end
+
+    def test_rbs_untyped_function
+      # Block of Thread#initialize `(*untyped) { (?) -> void } -> void` is RBS::Types::UntypedFunction
+      assert_call('Thread.new{_1.', include: NilClass)
+      assert_call('"a".instance_eval{Thread.new{self.', include: String)
+      # Proc#call `(?) -> untyped` is RBS::Types::UntypedFunction
+      assert_call('proc{}.call; 1.', include: Integer)
     end
   end
 end


### PR DESCRIPTION
Completion of `Thread.new{here}` does not work in RBS 3.6. This pull request fixes it.

Failed reason:
Some ruby core method types is changed in RBS 3.6
```rbs
# Thread#initialize
(*untyped) { (*untyped) -> void } -> void
# ↓
(*untyped) { (?) -> void } -> void

# Proc#call
(*untyped arg0) -> untyped
# ↓
(?) -> untyped
```
These method types is represented by RBS::Types::UntypedFunction added in RBS 3.5