### PR TITLE
Result#type and Result#prefix

### DIFF
--- a/lib/repl_type_completor/result.rb
+++ b/lib/repl_type_completor/result.rb
@@ -38,6 +38,14 @@ module ReplTypeCompletor
       @source_file = source_file
     end
 
+    def type
+      @analyze_result[0]
+    end
+
+    def prefix
+      @analyze_result[1]
+    end
+
     def completion_candidates
       verbose, $VERBOSE = $VERBOSE, nil
       candidates = case @analyze_result

--- a/sig/repl_type_completor.rbs
+++ b/sig/repl_type_completor.rbs
@@ -2,6 +2,8 @@ module ReplTypeCompletor
   VERSION: String
 
   class Result
+    def type: () -> Symbol
+    def prefix: () -> String
     def completion_candidates: () -> Array[String]
     def doc_namespace: (String) -> String?
   end

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -58,6 +58,9 @@ module TestReplTypeCompletor
     end
 
     def test_symbol
+      result = ReplTypeCompletor.analyze(':symbol_prefix', binding: binding)
+      assert_equal :symbol, result.type
+      assert_equal 'symbol_prefix', result.prefix
       prefix = ':test_com'
       sym = :test_completion_symbol
       assert_completion(prefix, include: sym.inspect.delete_prefix(prefix))


### PR DESCRIPTION
To handle and override Symbol.all_symbols completion in IRB.
I'm thinking of using this from https://github.com/ruby/irb/pull/1021

```ruby
result = ReplTypeCompletor.analyze(':sym', binding:)
result.type #=> :symbol
result.prefix #=> "sym"

result = ReplTypeCompletor.analyze('[1, "2"].map(&:to_', binding:)
result.type #=> :call
result.prefix #=> "to_"
# Receiver type(Integer|String) of this :call is not exposed.

result = ReplTypeCompletor.analyze('def f(abc = 1); ab', binding:)
result.type #=> :lvar_or_method # abc(lvar) or abort(method)
result.prefix #=> "ab"
# Scope object (including self type, local variables) is not exposed.
```

## Future plans
ReplTypeCompletor might drop returning `Symbol.all_symbols` because it has performance problem.
```ruby
result = ReplTypeCompletor.analyze("puts :a", binding:)
result.type #=> :symbol
result.completion_candidates #=> [] (always empty array)
```

ReplTypeCompletor might add symbol hash key completion
```ruby
hash = { foo: 1, bar: 2, baz: 3 }
result = ReplTypeCompletor.analyze("hash[:b", binding:)
result.type #=> :symbol or :symbol_hash_key(to distinguish from :symbol handled in IRB)
result.completion_candidates #=> ["ar", "az"]
```
