### PR TITLE
Limit the number of symbol completion candidates and make it faster

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -63,6 +63,16 @@ module TestReplTypeCompletor
       assert_completion(prefix, include: sym.inspect.delete_prefix(prefix))
     end
 
+    def test_symbol_limit
+      result = ReplTypeCompletor::Result.new([:symbol, 'sym'], binding, 'file')
+      symbols = [:ae, :ad, :ab1, :ab2, :ac, :aa, :b, :"a a", 75.chr('utf-7').to_sym]
+      assert_equal(%w[aa ab1 ab2 ac ad ae], result.send(:filter_symbol_candidates, symbols, 'a', limit: 100))
+      assert_equal(%w[aa ab1 ab2 ad ae], result.send(:filter_symbol_candidates, symbols, 'a', limit: 5))
+      assert_equal(%w[aa ab1 ad ae], result.send(:filter_symbol_candidates, symbols, 'a', limit: 4))
+      assert_equal(%w[ab1 ab2], result.send(:filter_symbol_candidates, symbols, 'ab', limit: 4))
+      assert_equal([], result.send(:filter_symbol_candidates, symbols, 'c', limit: 4))
+    end
+
     def test_call
       assert_completion('1.', include: 'abs')
       assert_completion('1.a', include: 'bs')


### PR DESCRIPTION
The number of symbol candidates can be huge.

Reduce calling `symbol.inspect` to make symbol search faster
```ruby
symbols = 100000.times.map{rand(36**rand(5..25)).to_s(36).to_sym};
symbols.map{_1.inspect[1..]}.select{_1.start_with? 'ab'};
# processing time: 0.063232s
symbols.select{_1.start_with? 'ab'}.filter_map{a=_1.inspect[1..];a if a.start_with? 'ab'};
# processing time: 0.017167s
```

Limit the number of symbol completion candidates. Avoid calling `large_symbol_array.sort` and use `min(n)+max(n).reverse`. This will also improve performance of rendering completion dialog in Reline.
```ruby
symbols.size
# => 100000
symbols.sort;
# processing time: 0.061497s
symbols.min(50)+symbols.max(50).reverse;
# processing time: 0.013646s
```
