### PR TITLE
Improve development experience

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -33,7 +33,13 @@ module ReplTypeCompletor
         gem_sig_path = File.expand_path("#{spec.gem_dir}/sig")
         loader.add(library: spec.name, version: spec.version) if Dir.exist?(gem_sig_path) && expanded_sig_path != gem_sig_path
       end
-      @rbs_builder = RBS::DefinitionBuilder.new env: RBS::Environment.from_loader(loader).resolve_type_names
+      env = RBS::Environment.from_loader(loader)
+      # [Hack] Monkey patch for improving development experience
+      def env.resolve_declaration(*, **)
+        Thread.pass
+        super
+      end
+      @rbs_builder = RBS::DefinitionBuilder.new env: env.resolve_type_names
     rescue LoadError, StandardError => e
       @rbs_load_error = e
       nil


### PR DESCRIPTION
## Problem

Loading a large number of RBSs will make the console heavy and the experience poor.
For example, loading the 'aws-sdk' gem will help reproduce this phenomenon.

```rb
# Gemfile
source 'https://rubygems.org'

gem 'aws-sdk'
```

```
$ bundle exec rbs collection install
```

```
$ bundle exec irb
```

I know that `RBS::Environment#resolve_type_names` is heavy, but I have not found a fundamental solution.

## Solution

I have found that calling `Thread.pass` at the appropriate time improves the experience in my environment.
Sorry, but I don't know if this improvement can be expected in many environments.
I tried Linux & x86_64 and Mac & M2 and felt improvement on both.

### Solution not selected

- Call `Thread.pass` in `RBS::Environment#add_signature`
    - Slow response when loading heavy signatures.
- Down `Thread#priority`
    - No improvement was observed.
- Use `sleep 0.001`
    - Improvement was felt, but delay was a concern.