### PR TITLE
Don't load gem's rbs if rbs_collection.yaml exists

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -29,10 +29,15 @@ module ReplTypeCompletor
       sig_path = Pathname('sig')
       loader.add path: sig_path
       expanded_sig_path = sig_path.expand_path.to_s
-      Gem.loaded_specs.values.each do |spec|
-        gem_sig_path = File.expand_path("#{spec.gem_dir}/sig")
-        loader.add(library: spec.name, version: spec.version) if Dir.exist?(gem_sig_path) && expanded_sig_path != gem_sig_path
+
+      unless File.exist?('rbs_collection.yaml')
+        # Load rbs signature from gems. This is a fallback when rbs_collection.yaml is not available.
+        Gem.loaded_specs.values.each do |spec|
+          gem_sig_path = File.expand_path("#{spec.gem_dir}/sig")
+          loader.add(library: spec.name, version: spec.version) if Dir.exist?(gem_sig_path) && expanded_sig_path != gem_sig_path
+        end
       end
+
       env = RBS::Environment.from_loader(loader)
       # [Hack] Monkey patch for improving development experience
       def env.resolve_declaration(*, **)


### PR DESCRIPTION
In rbs_collection.yaml, some gems can be ignored.

Ignored gems might have huge/heavy rbs files.
```
# gems:
#   # If you want to avoid installing rbs files for gems, you can specify them here.
#   - name: GEM_NAME
#     ignore: true
```

ReplTypeCompletor should follow rbs_collection.yaml configuration. When config file exists, additional gem's rbs file shouldn't be loaded.