### PR TITLE
Fix test_loaded_gem_types faling in test-bundled-gems

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -254,10 +254,9 @@ module TestReplTypeCompletor
     end
 
     def test_loaded_gem_types
-      result = ReplTypeCompletor.analyze 'Prism.parse("code").', binding: binding
+      result = ReplTypeCompletor.analyze 'RBS::CLI::LibraryOptions.new.loader.', binding: binding
       candidtes = result.completion_candidates
-      assert_includes candidtes, 'success?'
-      assert_includes candidtes, 'failure?'
+      assert_includes candidtes, 'add'
     end
 
     def test_info


### PR DESCRIPTION
Pre-installed Prism does not have `#{prism_gem_dir}/sig` dir.

```
# ruby -v
ruby 3.4.0dev (2024-12-16T01:23:31Z master 2aaed7d2e2) +PRISM [x86_64-linux]
# irb
irb(main):001> Gem.loaded_specs['prism'].gem_dir
=> "/opt/ruby/lib/ruby/gems/3.4.0+1/gems/prism-1.0.0"
irb(main):002> `ls #{Gem.loaded_specs['prism'].gem_dir}`
=> ""
```

Omit the failing test if `#{prism_gem_dir}/sig` does not exist.


Change test_loaded_gem_types to use signature defined in RBS instead of Prism.