### PR TITLE
Add test with preinstalled prism workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,20 @@ jobs:
       - run: bundle install
       - run: bundle exec rake test
 
+  test-preinstalled-prism:
+    needs: ruby-versions
+    runs-on: ubuntu-latest
+    env:
+      GEMFILE_USE_PREINSTALLED_PRISM: 1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: head
+          bundler-cache: true
+      - run: bundle install
+      - run: bundle exec rake test
+
   test-rbs-versions:
     needs: ruby-versions
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,13 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in repl_type_completor.gemspec
-gemspec
+if ENV['GEMFILE_USE_PREINSTALLED_PRISM']
+  # Preinstalled Prism is different from installed Prism. gem_dir is empty.
+  gem 'rbs'
+else
+  # Specify your gem's dependencies in repl_type_completor.gemspec
+  gemspec
+end
 
 gem 'irb', '>= 1.10.0'
 gem 'rake', '~> 13.0'


### PR DESCRIPTION
It can catch test failure like this
https://github.com/ruby/repl_type_completor/actions/runs/12345705071/job/34450199274
that failed in ruby/ruby ci's `make test-bundled-gems`