### PR TITLE
Fix test_loaded_gem_types faling in test-bundled-gems (take 2)

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -254,9 +254,13 @@ module TestReplTypeCompletor
     end
 
     def test_loaded_gem_types
-      result = ReplTypeCompletor.analyze 'RBS::CLI::LibraryOptions.new.loader.', binding: binding
+      # sig directory does not exist when running with test-bundled-gems
+      omit unless Dir.exist?("#{Gem.loaded_specs['prism'].gem_dir}/sig")
+
+      result = ReplTypeCompletor.analyze 'Prism.parse("code").', binding: binding
       candidtes = result.completion_candidates
-      assert_includes candidtes, 'add'
+      assert_includes candidtes, 'success?'
+      assert_includes candidtes, 'failure?'
     end
 
     def test_info


### PR DESCRIPTION
The fix in #46 was wrong.
`#{gem_dir}/sig` dir does not exist when running the test with `make test-bundled-gems`. We need to omit the test.

```
# Result of `ls #{Gem.loaded_specs['rbs'].gem_dir}`
ext
exts.mk
lib

# Result of `ls #{Gem.loaded_specs['prism'].gem_dir}`
(empty)
```