### PR TITLE
Fix test_loaded_gem_types faling in test-bundled-gems (take 3)

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -254,13 +254,12 @@ module TestReplTypeCompletor
     end
 
     def test_loaded_gem_types
-      # sig directory does not exist when running with test-bundled-gems
-      omit unless Dir.exist?("#{Gem.loaded_specs['prism'].gem_dir}/sig")
+      # gem_dir/sig directory does not exist when running with `make test-bundled-gems`
+      omit unless Dir.exist?("#{Gem.loaded_specs['rbs'].gem_dir}/sig")
 
-      result = ReplTypeCompletor.analyze 'Prism.parse("code").', binding: binding
+      result = ReplTypeCompletor.analyze 'RBS::CLI::LibraryOptions.new.loader.', binding: binding
       candidtes = result.completion_candidates
-      assert_includes candidtes, 'success?'
-      assert_includes candidtes, 'failure?'
+      assert_includes candidtes, 'add'
     end
 
     def test_info


### PR DESCRIPTION
#46 and #48 was both insufficient.

When running test-bundled-gems with `make test-bundled-gems`, `"prism"` does not appear in `Gem.loaded_specs`.
```ruby
require 'prism'; require 'rbs'
Gem.loaded_specs.keys #=> ['rbs']
```
When running test with `tool/test-bundled-gems.rb`, this does not happen.
```ruby
require 'prism'; require 'rbs'
Gem.loaded_specs.keys #=> ['prism', 'rbs']
```

So, we need to avoid using Prism as a loaded gem test (#46) and also need to omit test when RBS's gem_dir does not have sig directory (#48).
This pull request is a mix of #46 and #48.
