### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end


### PR DESCRIPTION
This version only includes fixes of ruby/ruby ci `make test-bundled-gems`


Running `make test-bundled-gems-run BUNDLED_GEMS=repl_type_completor`
```
# With repl_type_completor 0.1.8
Failed at
  => 259:       assert_includes candidtes, 'success?'

# With repl_type_completor 0.1.8 b16b0e5dd85b76c2e017600264c0c5620bc02c54
Failed at
  => 259:       assert_includes candidtes, 'add'

# With repl_type_completor 0.1.8 98249368573c10dd1398c84b4721dfbc29585696
Error at
  => 258:       omit unless Dir.exist?("#{Gem.loaded_specs['prism'].gem_dir}/sig")

# With the latest commit hash 3d8e382f6c8f398a3718b27a41b54fdfd8dccde9
Omission: omitted. [test_loaded_gem_types(TestReplTypeCompletor::ReplTypeCompletorTest)]
```
