### PR TITLE
Drop RBS 3.2 test and add RBS 3.3 and 3.8 test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rbs: ['latest', '3.6', '3.4', '3.2', '3.0', '2.7.0']
+        rbs: ['latest', '3.8', '3.6', '3.4', '3.3', '3.0', '2.7.0']
     env:
       GEMFILE_RBS_VERSION: ${{ matrix.rbs }}
     steps:


### PR DESCRIPTION
RBS 3.1.x and 3.2.x depends on abbrev but abbrev was not added to runtime dependency.
CI `test-rbs-versions (3.2)` is now failing because abbrev is not a default gem in Ruby 3.4.

Instead of adding `gem 'abbrev' if ENV['GEMFILE_RBS_VERSION' == '3.2'` to Gemfile, this pull request switch to use RBS 3.3 because the main purpose is just to test many RBS versions almost evenly.

Also adds RBS 3.8 which is bundled in Ruby 3.4.0