### PR TITLE
Fix nested it parameter completion

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -259,6 +259,9 @@ module ReplTypeCompletor
           call_block_proc = ->(block_args, block_self_type) do
             scope.conditional do |s|
               params_table = node.block.locals.to_h { [_1.to_s, Types::NIL] }
+              if node.block.parameters.is_a?(Prism::ItParametersNode)
+                params_table['_1'] = block_args.first || Types::NIL
+              end
               table = { **params_table, Scope::BREAK_RESULT => nil, Scope::NEXT_RESULT => nil }
               block_scope = Scope.new s, table, self_type: block_self_type, trace_ivar: !block_self_type
               # TODO kwargs
@@ -267,8 +270,6 @@ module ReplTypeCompletor
                 assign_numbered_parameters node.block.parameters.maximum, block_scope, block_args, {}
               when Prism::BlockParametersNode
                 assign_parameters node.block.parameters.parameters, block_scope, block_args, {}
-              when Prism::ItParametersNode
-                scope['_1'] = block_args.first || Types::NIL
               end
               result = node.block.body ? evaluate(node.block.body, block_scope) : Types::NIL
               block_scope.merge_jumps

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -560,6 +560,8 @@ module TestReplTypeCompletor
       assert_call('[1].tap{it.', include: Array)
       assert_call('loop{it.', include: NilClass, exclude: Object)
       assert_call('[:a].each_with_index{it.', include: Symbol, exclude: [Integer, Array])
+      assert_call(':outer.tap{p it; "inner".tap{p it; it.', include: String, exclude: Symbol)
+      assert_call(':outer.tap{p it; "inner".tap{p it }; it.', include: Symbol, exclude: String)
     end
 
     def test_if_unless


### PR DESCRIPTION
Fix this bug
```ruby
:outer.tap do
  p it # prints :outer
  'inner'.tap do
    p it # prints "inner"
  end
  p it # prints :outer
  p. # Bug here. Should show Symbol methods but it showed String methods
end
```

Adding it_parameter to block params_table was missing.
Other block parameters including numbered parameters are already in `node.block.locals` and added to params_table.
