### PR TITLE
Support completion of code including ShareableConstantNode

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -447,6 +447,10 @@ module ReplTypeCompletor
       Types::PROC
     end
 
+    def evaluate_shareable_constant_node(node, scope)
+      evaluate(node.write, scope)
+    end
+
     def evaluate_reference_write(node, scope)
       scope[node.name.to_s] = evaluate node.value, scope
     end

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -642,6 +642,10 @@ module TestReplTypeCompletor
       assert_call('Array::A=1; Array::A&&=1.0; Array::A.', include: Float)
     end
 
+    def test_shareable_constant_value
+      assert_call("#shareable_constant_value:literal\nA=1; A.", include: Integer)
+    end
+
     def test_case_when
       assert_call('case x; when A; 1; when B; 1.0; end.', include: [Integer, Float, NilClass])
       assert_call('case x; when A; 1; when B; 1.0; else; 1r; end.', include: [Integer, Float, Rational], exclude: NilClass)


### PR DESCRIPTION
Parse result of this code includes Prism::ShareableConstantNode. Handling this node was missing
```ruby
#shareable_constant_value:literal
A=1; A.a
```