### PR TITLE
Remove unnecessary `bundle install` on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test
 
   test-rbs-versions:
@@ -44,7 +43,6 @@ jobs:
         with:
           ruby-version: ${{ fromJson(needs.ruby-versions.outputs.latest) }}
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test
 
   test-prism-versions:
@@ -62,5 +60,4 @@ jobs:
         with:
           ruby-version: ${{ fromJson(needs.ruby-versions.outputs.latest) }}
           bundler-cache: true
-      - run: bundle install
       - run: bundle exec rake test


### PR DESCRIPTION
Bundler cache would already run `bundle install` on CI if the there's an dependency change. So manually running `bundle install` is unnecessary.