### PR TITLE
Change InstanceType structure

### DIFF
--- a/lib/repl_type_completor/methods.rb
+++ b/lib/repl_type_completor/methods.rb
@@ -2,7 +2,8 @@
 
 module ReplTypeCompletor
   module Methods
-    OBJECT_SINGLETON_CLASS_METHOD = Object.instance_method(:singleton_class)
+    OBJECT_SINGLETON_METHODS_METHOD = Object.instance_method(:singleton_methods)
+    OBJECT_PRIVATE_METHODS_METHOD = Object.instance_method(:private_methods)
     OBJECT_INSTANCE_VARIABLES_METHOD = Object.instance_method(:instance_variables)
     OBJECT_INSTANCE_VARIABLE_GET_METHOD = Object.instance_method(:instance_variable_get)
     OBJECT_CLASS_METHOD = Object.instance_method(:class)

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -197,6 +197,26 @@ module TestReplTypeCompletor
       assert_doc_namespace('m.ancestors', 'Module.ancestors', binding: bind)
     end
 
+    def test_array_singleton_method
+      assert_completion('$LOAD_PATH.', include: 'resolve_feature_path')
+      assert_completion('$LOAD_PATH.itself.', include: 'resolve_feature_path')
+      assert_completion('[$LOAD_PATH].first.', include: 'resolve_feature_path')
+      assert_completion('{ x: $LOAD_PATH }.each_value { _1.', include: 'resolve_feature_path')
+    end
+
+    def test_recursive_array
+      a = Object.new
+      b = Object.new
+      def a.foobar; end
+      def b.foobaz; end
+      arr = [a, [b]]
+      arr[1] << arr
+      bind = binding
+      assert_completion('arr.sample.foo', binding: bind, include: 'bar', exclude: 'baz')
+      assert_completion('arr.sample.sample.foo', binding: bind, include: 'baz', exclude: 'bar')
+      assert_completion('arr.sample.sample.sample.foo', binding: bind, include: 'bar', exclude: 'baz')
+    end
+
     DEPRECATED_CONST = 1
     deprecate_constant :DEPRECATED_CONST
     def test_deprecated_const_without_warning


### PR DESCRIPTION
Fixes #51
Reduce unnecessarily creating singleton classes
Fix warning `test_type_analyze.rb:45: warning: literal string will be frozen in the future`
Improve completion of deeply nested array/hash

Structure change:
```ruby
class InstanceType
  klass # Class or singleton class
  params # Params hash
end
# ↓
class InstanceType
  klass # Class
  params # Params hash or nil(== not calculated yet)
  instances # nil or array of actual instances
end
```


Actual object type was represented by `InstanceType.new(object.singleton_class)`. It was unnecessarily creating singleton classes.
```ruby
# type of `[a1, a2, a3]`

# Before
Array[Elem: (a1.singleton_class) | (a2.singleton_class) | (b1.singleton_class)]

# After
Array[Elem: A(instances=[a1, a2]) | B(instances=[b1])]
```

Actual array type was represented by `InstanceType.new(Array, { Elem: ElemType })`. Information of singleton methods was lost.
```ruby
irb(main):001> a = { x: [{ x: 1 }] }

# Before: Params are expanded with depth=1 when local variable is referenced
a #=> Hash[K: Symbol, V: Array]

# After: Params are lazily expanded
a #=> Hash[?]
a.itself #=> Hash[K: Symbol, V: Array[?]]
a.values.itself #=> Array[Elem: Array[?]]
a.values.first #=> Array[Elem: Hash[?]]
a.values.first.first #=> Elem: Hash[?]
a.values.first.first.itself #=> Elem: Hash[K: Symbol, V: Integer]
```
Type of actual Array/Hash contains actual instances, so singleton methods are retained.

Lazily expanding params will make it possible to show completion on recursive array.
```ruby
irb(main):001> a = {x: []}; a[:x] << a
=> [{x: [...]}]
irb(main):002> a.values.first.sample.values.first.va # completes "values_at"
irb(main):003> a.values.first.sample.values.first.sample.va # completes "value?", "values" and "values_at"
```

## Future plans
Literal types can be represented by `InstanceType.new(Symbol, params=nil, instances=[:symbol_literal1, :symbol_literal2])`
Implementing hash key completion `hash[:here]` will be easier. 