### PR TITLE
Bump version to 0.1.10

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
https://github.com/ruby/repl_type_completor/compare/v0.1.9...79b456de4c0a2215247676aa95100b45afd8fd52