### PR TITLE
Handle RBS::Types::Intersection (fallback to union type)

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -406,7 +406,8 @@ module ReplTypeCompletor
             OBJECT
           end
         end
-      when RBS::Types::Union
+      when RBS::Types::Union, RBS::Types::Intersection
+        # Intersection is unsupported. fallback to union type
         UnionType[*return_type.types.map { from_rbs_type _1, self_type, extra_vars }]
       when RBS::Types::Proc
         PROC
@@ -455,6 +456,8 @@ module ReplTypeCompletor
           params = names.map.with_index { [_1, args[_2] || OBJECT] }.to_h
         end
         InstanceType.new klass, params || {}
+      else
+        OBJECT
       end
     end
 

--- a/test/repl_type_completor/test_type_analyze.rb
+++ b/test/repl_type_completor/test_type_analyze.rb
@@ -744,6 +744,11 @@ module TestReplTypeCompletor
       assert_call('proc{}.call; 1.', include: Integer)
     end
 
+    def test_rbs_intersection_type_fallback
+      # One of the overloads of Kernel.Rational(a, b) has `Numeric & _RationalDiv[T]`
+      assert_call('Rational(a,b).', include: Rational)
+    end
+
     def test_rbs_instance_type
       assert_call('Thread.start{}.', include: Thread)
       assert_call('"".encode("utf-8").', include: String)


### PR DESCRIPTION
Fix this bug
```ruby
irb(main):001> Rational(1,2). # no completion
irb(main):001> ReplTypeCompletor.last_completion_error
=> #<NoMethodError: undefined method 'types' for nil>
```

Type definition of Kernel.Rational includes IntersectionType `Numeric & _RationalDiv[T]`
```rbs
  def self?.Rational: (int | _ToR rational_like, ?exception: true) -> Rational
                    | (int | _ToR rational_like, exception: bool) -> Rational?
                    | (int | _ToR numer, ?int | _ToR denom, ?exception: true) -> Rational
                    | (int | _ToR numer, ?int | _ToR denom, exception: bool) -> Rational?
                    | [T] (Numeric & _RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
                    | [T < Numeric] (T value, 1, ?exception: bool) -> T
                    | (untyped, ?untyped, ?exception: bool) -> Rational?

```

Handle Intersection as Union as a fallback is better than doing nothing.

Note:
- ReplTypeCompletor does not have type narrowing
- ReplTypeCompletor shows all possible methods for UnionType, so the difference of Union and Intersection is small
- Normally, intersection type is an intersection of InterfaceType and it is not supported yet
