### PR TITLE
Improve inspect of recursively nested types

### DIFF
--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -273,7 +273,9 @@ module ReplTypeCompletor
       end
 
       def inspect
-        if params.empty?
+        if !@params && (@klass == Array || @klass == Hash) && @instances
+          "#{inspect_without_params}[unresolved]"
+        elsif params.empty?
           inspect_without_params
         else
           params_string = "[#{params.map { "#{_1}: #{_2.inspect}" }.join(', ')}]"


### PR DESCRIPTION
Fix this stack level too deep error while inspecting recursive type.
```ruby
a=[]
a << a
result = ReplTypeCompletor.analyze('a.each{it.each{it.each_w', binding:)
# Completion is working
result.completion_candidates #=> ["ith_index", "ith_object"]
# Inspect is not working
result.inspect # => stack level too deep (SystemStackError)
```

This change does not affect completion. It just helps debugging repl_type_completor itself.

```ruby
type = ReplTypeCompletor::Types.type_from_object([[1]])

# Before. inspect has side effect that recursively expands all unresolved params.
type.inspect #=> Array[Elem: Array[Elem: Integer]]

# After. inspect does not have side effect.
type.inspect #=> Array[unresolved]
type.params #=> {Elem: Array[unresolved]}
type.inspect #=> Array[Elem: Array[unresolved]]
type.params[:Elem].params #=> {Elem: Integer}
type.inspect #=> Array[Elem: Array[Elem: Integer]]
```
