### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end


### PR DESCRIPTION
https://github.com/ruby/repl_type_completor/compare/v0.1.10...366c2c6e92737bc85c69b026f00c52cf66087a6d
