### PR TITLE
Change require path completion test not to use 'set'

### DIFF
--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -34,10 +34,11 @@ module TestReplTypeCompletor
     end
 
     def test_require
-      assert_completion("require '", include: 'set')
-      assert_completion("require 's", include: 'et')
-      assert_completion('require "', include: 'set')
-      assert_completion('require "s', include: 'et')
+      assert_completion("require '", include: 'repl_type_completor')
+      assert_completion("require 'r", include: 'epl_type_completor')
+      assert_completion('require "', include: 'repl_type_completor')
+      assert_completion('require "r', include: 'epl_type_completor')
+      assert_completion('require_relative "r', exclude: 'epl_type_completor')
       assert_completion("require_relative 'test_", filename: __FILE__, include: 'repl_type_completor')
       assert_completion("require_relative '../repl_", filename: __FILE__, include: 'type_completor/test_repl_type_completor')
       Dir.chdir File.join(__dir__, '..') do


### PR DESCRIPTION
The test `assert_completion("require '", include: 'set')` is failing in ruby-head.

Set is now a core class in Ruby 3.5.0dev
Change completion test of require path to use `require 'repl_type_completor'` instead of `require 'set'`