### PR TITLE
Add completion for hash aref

### DIFF
--- a/lib/repl_type_completor.rb
+++ b/lib/repl_type_completor.rb
@@ -59,6 +59,15 @@ module ReplTypeCompletor
 
     private
 
+    # Checks if `*parents, target_node` returned by `find_target` is a call with a single argument.
+    # returns CallNode or nil.
+    def single_arg_call_node(parents)
+      call_node, args_node = parents.last(2)
+      if call_node.is_a?(Prism::CallNode) && args_node.is_a?(Prism::ArgumentsNode) && args_node.arguments.size == 1
+        call_node
+      end
+    end
+
     def analyze_code(code, binding = Object::TOPLEVEL_BINDING)
       ast = Prism.parse(code, scopes: [binding.local_variables]).value
       *parents, target_node = find_target ast, code.bytesize
@@ -71,12 +80,12 @@ module ReplTypeCompletor
       when Prism::StringNode
         return if target_node.opening == "?" || (target_node.closing_loc && !target_node.closing.empty?)
 
-        call_node, args_node = parents.last(2)
-        return unless call_node.is_a?(Prism::CallNode) && call_node.receiver.nil?
-        return unless args_node.is_a?(Prism::ArgumentsNode) && args_node.arguments.size == 1
-
-        if call_node.name == :require || call_node.name == :require_relative
+        call_node = single_arg_call_node(parents) # require("target") or require_relative("target")
+        if call_node.receiver.nil? && (call_node.name == :require || call_node.name == :require_relative)
           [call_node.name, target_node.content]
+        elsif call_node.receiver && call_node.name == :[] # object["target"]
+          receiver_type, _scope = calculate_type_scope.call call_node.receiver
+          [:aref, :string, target_node.content, receiver_type]
         end
       when Prism::SymbolNode
         return unless !target_node.closing || target_node.closing.empty?
@@ -85,6 +94,9 @@ module ReplTypeCompletor
         if parents.last.is_a? Prism::BlockArgumentNode # method(&:target)
           receiver_type, _scope = calculate_type_scope.call target_node
           [:call, name, receiver_type, false]
+        elsif (call_node = single_arg_call_node(parents)) && call_node.receiver && call_node.name == :[] # object[:target]
+          receiver_type, _scope = calculate_type_scope.call call_node.receiver
+          [:aref, :symbol, name, receiver_type]
         else
           [:symbol, name] unless name.empty?
         end

--- a/lib/repl_type_completor/result.rb
+++ b/lib/repl_type_completor/result.rb
@@ -65,6 +65,19 @@ module ReplTypeCompletor
         scope.global_variables
       in [:symbol, name]
         filter_symbol_candidates(Symbol.all_symbols, name, limit: 100)
+      in [:aref, key_type, name, receiver_type]
+        key_type = key_type == :string ? String : Symbol
+        keys = receiver_type.types.grep(Types::InstanceType).select do |t|
+          Hash == t.klass
+        end.flat_map do |t|
+          t.instances.flat_map(&:keys).grep(key_type).uniq.sort
+        end
+        if key_type == Symbol
+          keys = Symbol.all_symbols if keys.empty? && name.size >= 1
+          filter_symbol_candidates(keys, name, limit: 100)
+        else
+          keys.select { _1.start_with?(name) }.sort
+        end
       in [:call, name, type, self_call]
         (self_call ? type.all_methods : type.methods).map(&:to_s) - HIDDEN_METHODS
       in [:lvar_or_method, name, scope]

--- a/test/repl_type_completor/test_repl_type_completor.rb
+++ b/test/repl_type_completor/test_repl_type_completor.rb
@@ -58,6 +58,32 @@ module TestReplTypeCompletor
       assert_doc_namespace('[1].map(&:abs', 'Integer#abs')
     end
 
+    def test_hash_aref
+      hash1 = { key1: 1, other_key1: 2, 'string_key1' => 3 }
+      hash2 = { key2: 1, other_key2: 2, 'string_key2' => 3 }
+      never_hash = { key3: 1, other_key3: 2, 'string_key3' => 3 }
+      exclude_keys = never_hash.keys.map(&:to_s)
+      array = [hash1, hash2, 1, 'a']
+      symbol_keys = array.grep(Hash).flat_map(&:keys).grep(Symbol).map(&:to_s)
+      string_keys = array.grep(Hash).flat_map(&:keys).grep(String)
+      bind = binding
+      assert_completion('hash1[:', binding: bind, include: hash1.keys.grep(Symbol).map(&:to_s), exclude: hash2.keys.map(&:to_s))
+      assert_completion('hash1["', binding: bind, include: hash1.keys.grep(String), exclude: hash2.keys.map(&:to_s))
+      assert_completion('hash1[:ke', binding: bind, include: 'y1', exclude: 'y3')
+      assert_completion('hash1["st', binding: bind, include: 'ring_key1', exclude: 'ring_key2')
+      assert_completion('array.sample[:', binding: bind, include: symbol_keys, exclude: exclude_keys + string_keys)
+      assert_completion('array.sample["', binding: bind, include: string_keys, exclude: exclude_keys + symbol_keys)
+      assert_completion('a = hash1; a = hash2 if cond; a[:', binding: bind, include: symbol_keys, exclude: exclude_keys + string_keys)
+      assert_completion('a = hash1; a = hash2 if cond; a["', binding: bind, include: string_keys, exclude: exclude_keys + symbol_keys)
+
+      # Fallback to all symbols for unknown receiver or hash with unknown keys
+      assert_completion('unknown[:', exclude: ['key1', 'key2', 'key3']) # no candidates if name is empty
+      assert_completion('unknown[:other_k', include: ['ey1', 'ey2', 'ey3'])
+      assert_completion('unknown["other_k', exclude: ['ey1', 'ey2', 'ey3']) # no candidates for string keys
+      assert_completion('Class[:other_k', include: ['ey1', 'ey2', 'ey3'])
+      assert_completion('hash1.slice(unknown)[:other_k', include: ['ey1', 'ey2', 'ey3'])
+    end
+
     def test_symbol
       prefix = ':test_com'
       sym = :test_completion_symbol


### PR DESCRIPTION
`hash[:` and `hash['` will complete hash keys for some case (e.g. hash is a local variable)

```
irb(main):001> data = { foo: 1, 'bar' => 2 }
=> {foo: 1, "bar" => 2}
irb(main):002* data[:█
               data[:foo
```

```
irb(main):001> data = { foo: 1, 'bar' => 2 }
=> {foo: 1, "bar" => 2}
irb(main):002' data['█
               data['bar
```