### PR TITLE
ErrorRecoveryNode for prism

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -821,6 +821,10 @@ module ReplTypeCompletor
     def evaluate_undef_node(_node, _scope) = Types::NIL
     def evaluate_missing_node(_node, _scope) = Types::NIL
 
+    def evaluate_error_recovery_node(node, scope)
+      node.unexpected ? evaluate(node.unexpected, scope) : Types::NIL
+    end
+
     def evaluate_call_node_arguments(call_node, scope)
       # call_node.arguments is Prism::ArgumentsNode
       arguments = call_node.arguments&.arguments&.dup || []


### PR DESCRIPTION
We are going to introduce a catch-all error recovery node in prism. In order to get it merged, I need this merged and updated in CRuby. See:

https://github.com/ruby/prism/pull/3843

and

https://github.com/ruby/ruby/pull/16489