### PR TITLE
Treat type params as positional params

### DIFF
--- a/lib/repl_type_completor/type_analyzer.rb
+++ b/lib/repl_type_completor/type_analyzer.rb
@@ -177,15 +177,15 @@ module ReplTypeCompletor
             hash = method_call hash, :to_hash, [], nil, nil, scope
           end
           if hash.is_a?(Types::InstanceType) && hash.klass == Hash
-            keys << hash.params[:K] if hash.params[:K]
-            values << hash.params[:V] if hash.params[:V]
+            keys << hash.params[0] if hash.params[0]
+            values << hash.params[1] if hash.params[1]
           end
         end
       end
       if keys.empty? && values.empty?
-        Types::InstanceType.new Hash
+        Types::InstanceType.new(Hash)
       else
-        Types::InstanceType.new Hash, K: Types::UnionType[*keys], V: Types::UnionType[*values]
+        Types::InstanceType.new(Hash, [Types::UnionType[*keys], Types::UnionType[*values]])
       end
     end
 
@@ -706,7 +706,7 @@ module ReplTypeCompletor
       inner_scope = Scope.new scope, { Scope::BREAK_RESULT => nil }
       ary_type = method_call collection, :to_ary, [], nil, nil, nil, name_match: false
       element_types = ary_type.types.filter_map do |ary|
-        ary.params[:Elem] if ary.is_a?(Types::InstanceType) && ary.klass == Array
+        ary.params[0] if ary.is_a?(Types::InstanceType) && ary.klass == Array
       end
       element_type = Types::UnionType[*element_types]
       inner_scope.conditional do |s|
@@ -761,7 +761,7 @@ module ReplTypeCompletor
       beg_type = evaluate node.left, scope if node.left
       end_type = evaluate node.right, scope if node.right
       elem = (Types::UnionType[*[beg_type, end_type].compact]).nonnillable
-      Types::InstanceType.new Range, Elem: elem
+      Types::InstanceType.new(Range, [elem])
     end
 
     def evaluate_defined_node(node, scope)
@@ -958,7 +958,7 @@ module ReplTypeCompletor
       end
       # node.keyword_rest is Prism::KeywordRestParameterNode or Prism::ForwardingParameterNode or Prism::NoKeywordsParameterNode
       if node.keyword_rest.is_a?(Prism::KeywordRestParameterNode) && node.keyword_rest.name
-        scope[node.keyword_rest.name.to_s] = Types::InstanceType.new(Hash, K: Types::SYMBOL, V: Types::UnionType[*kwargs.values])
+        scope[node.keyword_rest.name.to_s] = Types::InstanceType.new(Hash, [Types::SYMBOL, Types::UnionType[*kwargs.values]])
       end
       if node.block&.name
         # node.block is Prism::BlockParameterNode
@@ -1143,7 +1143,7 @@ module ReplTypeCompletor
           true
         end
       end
-      array_elem = arrays.empty? ? nil : Types::UnionType[*arrays.map { _1.params[:Elem] || Types::OBJECT }]
+      array_elem = arrays.empty? ? nil : Types::UnionType[*arrays.map { _1.params[0] || Types::OBJECT }]
       non_array = non_arrays.empty? ? nil : Types::UnionType[*non_arrays]
       [array_elem, non_array]
     end
@@ -1152,7 +1152,7 @@ module ReplTypeCompletor
       methods = Types.rbs_methods receiver, method_name.to_sym, args, kwargs, !!block
       block_called = false
       type_breaks = methods.map do |method, given_params, method_params|
-        receiver_vars = receiver.is_a?(Types::InstanceType) ? receiver.params : {}
+        receiver_vars = receiver.is_a?(Types::InstanceType) ? receiver.named_params : {}
         free_vars = method.type.free_variables - receiver_vars.keys.to_set
         vars = receiver_vars.merge Types.match_free_variables(free_vars, method_params, given_params)
         if block && method.block && method.block.type.respond_to?(:required_positionals)

--- a/lib/repl_type_completor/types.rb
+++ b/lib/repl_type_completor/types.rb
@@ -157,7 +157,7 @@ module ReplTypeCompletor
           args = args_types
           if kwargs_type&.any? && keyreqs.empty? && keyopts.empty? && keyrest.nil?
             kw_value_type = UnionType[*kwargs_type.values]
-            args += [InstanceType.new(Hash, K: SYMBOL, V: kw_value_type)]
+            args += [InstanceType.new(Hash, [SYMBOL, kw_value_type])]
           end
           if has_splat
             score += 1 if args.count(&:itself) <= reqs.size + opts.size + trailings.size
@@ -270,20 +270,29 @@ module ReplTypeCompletor
         @params ||= expand_params
       end
 
+      def named_params
+        return {} if params.empty?
+        if Types.rbs_builder
+          type_name = Types.rbs_absolute_type_name(Types.class_name_of(@klass))
+          names = Types.rbs_builder.build_instance(type_name)&.type_params rescue nil
+        end
+        names ? names.zip(params).to_h.compact : {}
+      end
+
       def expand_params
-        params = @raw_params || {}
+        params = @raw_params || []
         return params unless @instances
 
         if @klass == Array
           type = Types.union_type_from_objects_list(@instances)
-          { Elem: UnionType[*params[:Elem], *type] }
+          [UnionType[*params[0], *type]]
         elsif @klass == Hash
           key = Types.union_type_from_objects_list(@instances.map(&:keys))
           value = Types.union_type_from_objects_list(@instances.map(&:values))
-          {
-            K: UnionType[*params[:K], key],
-            V: UnionType[*params[:V], value]
-          }
+          [
+            UnionType[*params[0], key],
+            UnionType[*params[1], value]
+          ]
         else
           params
         end
@@ -308,7 +317,12 @@ module ReplTypeCompletor
         elsif params.empty?
           inspect_without_params
         else
-          params_string = "[#{params.map { "#{_1}: #{_2.inspect}" }.join(', ')}]"
+          named = named_params
+          if named.empty? && !params.empty?
+            params_string = "[#{params.map(&:inspect).join(', ')}]"
+          else
+            params_string = "[#{named.map { "#{_1}: #{_2.inspect}" }.join(', ')}]"
+          end
           "#{inspect_without_params}#{params_string}"
         end
       end
@@ -356,10 +370,10 @@ module ReplTypeCompletor
           in UnionType
             type.types.each(&collect)
           in InstanceType
-            params, instances = (instance_types[type.klass] ||= [{}, []])
+            params, instances = (instance_types[type.klass] ||= [[], []])
             type.instances&.each { instances << _1 }
-            type.raw_params&.each do |k, v|
-              (params[k] ||= []) << v
+            type.raw_params&.each_with_index do |v, index|
+              (params[index] ||= []) << v
             end
           in SingletonType
             singleton_types << type
@@ -367,7 +381,7 @@ module ReplTypeCompletor
         end
         types.each(&collect)
         @types = singleton_types.uniq + instance_types.map do |klass, (params, instances)|
-          params = params.transform_values { |v| UnionType[*v] }
+          params = params.map { |v| UnionType[*v] }
           InstanceType.new(klass, params, instances)
         end
       end
@@ -405,7 +419,7 @@ module ReplTypeCompletor
 
     def self.array_of(*types)
       type = types.size >= 2 ? UnionType[*types] : types.first || OBJECT
-      InstanceType.new Array, Elem: type
+      InstanceType.new(Array, [type])
     end
 
     def self.from_rbs_type(return_type, self_type, extra_vars = {})
@@ -445,19 +459,19 @@ module ReplTypeCompletor
         PROC
       when RBS::Types::Tuple
         elem = UnionType[*return_type.types.map { from_rbs_type _1, self_type, extra_vars }]
-        InstanceType.new Array, Elem: elem
+        InstanceType.new(Array, [elem])
       when RBS::Types::Record
-        InstanceType.new Hash, K: SYMBOL, V: OBJECT
+        InstanceType.new(Hash, [SYMBOL, OBJECT])
       when RBS::Types::Literal
         InstanceType.new return_type.literal.class
       when RBS::Types::Variable
         if extra_vars.key? return_type.name
           extra_vars[return_type.name]
         elsif self_type.is_a? InstanceType
-          self_type.params[return_type.name] || OBJECT
+          self_type.named_params[return_type.name] || OBJECT
         elsif self_type.is_a? UnionType
           types = self_type.types.filter_map do |t|
-            t.params[return_type.name] if t.is_a? InstanceType
+            t.named_params[return_type.name] if t.is_a? InstanceType
           end
           UnionType[*types]
         else
@@ -483,11 +497,9 @@ module ReplTypeCompletor
       when RBS::Types::ClassInstance
         klass = return_type.name.to_namespace.path.reduce(Object) { _1.const_get _2 }
         if return_type.args
-          args = return_type.args.map { from_rbs_type _1, self_type, extra_vars }
-          names = rbs_builder.build_singleton(return_type.name).type_params
-          params = names.map.with_index { [_1, args[_2] || OBJECT] }.to_h
+          params = return_type.args.map { from_rbs_type _1, self_type, extra_vars }
         end
-        InstanceType.new klass, params || {}
+        InstanceType.new(klass, params || [])
       else
         OBJECT
       end
@@ -512,11 +524,11 @@ module ReplTypeCompletor
       in [RBS::Types::ClassInstance, InstanceType]
         names = rbs_builder.build_singleton(rbs_type.name).type_params
         names.zip(rbs_type.args).each do |name, arg|
-          v = value.params[name]
+          v = value.named_params[name]
           _match_free_variable vars, arg, v, accumulator if v
         end
       in [RBS::Types::Tuple, InstanceType] if value.klass == Array
-        v = value.params[:Elem]
+        v = value.params[0]
         rbs_type.types.each do |t|
           _match_free_variable vars, t, v, accumulator
         end

--- a/test/repl_type_completor/test_types.rb
+++ b/test/repl_type_completor/test_types.rb
@@ -11,14 +11,14 @@ module TestReplTypeCompletor
       nil_type = ReplTypeCompletor::Types::NIL
       string_type = ReplTypeCompletor::Types::STRING
       true_or_false = ReplTypeCompletor::Types::UnionType[true_type, false_type]
-      array_type = ReplTypeCompletor::Types::InstanceType.new Array, { Elem: true_or_false }
+      array_type = ReplTypeCompletor::Types::InstanceType.new(Array, [true_or_false])
       assert_equal 'nil', nil_type.inspect
       assert_equal 'true', true_type.inspect
       assert_equal 'false', false_type.inspect
       assert_equal 'String', string_type.inspect
       assert_equal 'Array', ReplTypeCompletor::Types::InstanceType.new(Array).inspect
       assert_equal 'false | true', true_or_false.inspect
-      assert_equal 'Array[Elem: false | true]', array_type.inspect
+      assert_include ['Array[E: false | true]', 'Array[Elem: false | true]'], array_type.inspect
       assert_equal 'Array', array_type.inspect_without_params
       assert_equal 'Proc', ReplTypeCompletor::Types::PROC.inspect
       assert_equal 'Array.itself', ReplTypeCompletor::Types::SingletonType.new(Array).inspect
@@ -51,12 +51,12 @@ module TestReplTypeCompletor
       assert_equal Hash, hash_type.klass
       assert_equal Hash, bo_key_hash_type.klass
       assert_equal Hash, bo_value_hash_type.klass
-      assert_equal BasicObject, bo_arr_type.params[:Elem].klass
-      assert_equal BasicObject, bo_key_hash_type.params[:K].klass
-      assert_equal BasicObject, bo_value_hash_type.params[:V].klass
+      assert_equal BasicObject, bo_arr_type.params[0].klass
+      assert_equal BasicObject, bo_key_hash_type.params[0].klass
+      assert_equal BasicObject, bo_value_hash_type.params[1].klass
       assert_equal 'Object', obj_type.inspect
       assert_equal 'Array[unresolved]', arr_type.inspect
-      assert_equal 'Array[Elem: Integer | String]', arr_type.tap(&:params).inspect
+      assert_include ['Array[E: Integer | String]', 'Array[Elem: Integer | String]'], arr_type.tap(&:params).inspect
       assert_equal 'Hash[unresolved]', hash_type.inspect
       assert_equal 'Hash[K: String, V: Symbol]', hash_type.tap(&:params).inspect
       assert_equal 'Array.itself', ReplTypeCompletor::Types.type_from_object(Array).inspect
@@ -109,12 +109,12 @@ module TestReplTypeCompletor
       type = ReplTypeCompletor::Types.type_from_object a
       assert_equal Array, type.klass
       10.times do |i|
-        elem_type = type.params[:Elem]
+        elem_type = type.params[0]
         expected = i.even? ? [Array, String] : [Array, Symbol]
         assert_equal expected, elem_type.types.map(&:klass).sort_by(&:name)
         type = elem_type.types.find { _1.klass == Array }
       end
-      hash_type = type.params[:Elem].types.find { _1.klass == Hash }
+      hash_type = type.params[0].types.find { _1.klass == Hash }
       assert_equal 'Hash[unresolved]', hash_type.inspect
       assert_equal 'Hash[K: Integer, V: Float]', hash_type.tap(&:params).inspect
     end
@@ -124,7 +124,7 @@ module TestReplTypeCompletor
       a << a
       type = ReplTypeCompletor::Types.type_from_object a
       assert_equal 'Array[unresolved]', type.inspect
-      assert_equal 'Array[Elem: Array[unresolved]]', type.tap(&:params).inspect
+      assert_include ['Array[E: Array[unresolved]]', 'Array[Elem: Array[unresolved]]'], type.tap(&:params).inspect
     end
   end
 end


### PR DESCRIPTION
Fixes CI failure.
CI was failing because ReplTypeCompletor was using hardcoded type param name of Array(Elem) and Hash(K, V). Type param name of Array has been changed from `Elem` to `E` in RBS HEAD.

To not rely on Array's type param name, `InstanceType#params` is changed from named params(Hash) to positional params(Array).