### PR TITLE
Bump version to 0.1.16

### DIFF
--- a/lib/repl_type_completor/version.rb
+++ b/lib/repl_type_completor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReplTypeCompletor
-  VERSION = "0.1.15"
+  VERSION = "0.1.16"
 end


### PR DESCRIPTION
Supports recent RBS changes
https://github.com/ruby/repl_type_completor/compare/v0.1.15...bump_ver_0_1_16